### PR TITLE
Launder the request to avoid UB

### DIFF
--- a/src/event/io_uring_core_impl.cpp
+++ b/src/event/io_uring_core_impl.cpp
@@ -171,6 +171,7 @@ auto io_uring_core_impl::run() noexcept -> void {
                 ++cqe_count;
                 auto *request = static_cast<io_request *>(io_uring_cqe_get_data(cqe));
                 if (request) {
+                    request = std::launder(request);
                     switch (request->type()) {
                     case io_request::request_type::accept:
                         request->socket().on_accept(request, cqe->res);


### PR DESCRIPTION
Also, liburing relies on UB heavily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved type safety and object lifetime handling for request pointers in the completion queue processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->